### PR TITLE
Add display feature support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ It uses `yarn` for package management, and `parcel` for bundling the various mod
   - graphics / logos
   - 3d models for parts
   - knob caps / fader caps
-  - displays (LCD, 8-segment)
+  - ~~displays (LCD, 8-segment)~~
+  - display cutouts (OLED, TFT, character LCD)
   - header pins
   - generic hole / round-rect / rect cutouts for whatever you want
   - PCB outline exporting (w or w/o marks for where features should go)

--- a/src/info.js
+++ b/src/info.js
@@ -29,7 +29,8 @@ const info = {
       rotarypot: "Rotary Potentiometer",
       slidepot: "Slide Potentiometer",
       toggleswitch: "Toggle Switch",
-      led: "LED"
+      led: "LED",
+      display: "Display"
     },
   
     // horizontal pitch options
@@ -92,6 +93,18 @@ const info = {
         { display:  "5x2mm rectangle",      identifier: "5x2mm-rect",  size: [5, 2] , shape: ShapeTypes.Rectangle },
         { display:  "3mm round",            identifier: "3mm-round",   size: 3      , shape: ShapeTypes.Circle },
         { display:  "1.8mm round",          identifier: "1.8mm-round", size: 1.8    , shape: ShapeTypes.Circle },
+      ],
+      display: [
+        { display: "0.96\" OLED (128x64)",    identifier: "oled-0.96",     size: [24, 14], shape: ShapeTypes.Rectangle },
+        { display: "1.3\" OLED (128x64)",     identifier: "oled-1.3-64",  size: [30, 18], shape: ShapeTypes.Rectangle },
+        { display: "1.3\" OLED (128x128)",    identifier: "oled-1.3-128", size: [28, 28], shape: ShapeTypes.Rectangle },
+        { display: "1.5\" OLED (128x128)",    identifier: "oled-1.5-128", size: [32, 32], shape: ShapeTypes.Rectangle },
+        { display: "1.3-2\" TFT (240x240)",   identifier: "tft-240",      size: [34, 34], shape: ShapeTypes.Rectangle },
+        { display: "2.4-2.8\" TFT (320x240)", identifier: "tft-320",      size: [55, 40], shape: ShapeTypes.Rectangle },
+        { display: "3.2\" TFT (480x320)",     identifier: "tft-480",      size: [72, 53], shape: ShapeTypes.Rectangle },
+        { display: "16x2 Character LCD",      identifier: "char-16x2",    size: [60, 16], shape: ShapeTypes.Rectangle },
+        { display: "20x4 Character LCD",      identifier: "char-20x4",    size: [76, 25], shape: ShapeTypes.Rectangle },
+        { display: "Single 7-seg",            identifier: "7seg",         size: [10, 18], shape: ShapeTypes.Rectangle }
       ]
     },
 
@@ -101,6 +114,7 @@ const info = {
       slidepot: 2,
       toggleswitch: 1,
       led: 0,
+      display: 0,
     },
   
     // these are potential positioning frames of reference.

--- a/src/lasers.html
+++ b/src/lasers.html
@@ -220,6 +220,12 @@
       Examples of the type of leds here
     </p>
   </details>
+  <details id="display-info">
+    <summary>Displays</summary>
+    <p>
+      Examples of OLED, TFT and character LCD modules.
+    </p>
+  </details>
 
   <details open>
     <summary>Getting panels cut</summary>


### PR DESCRIPTION
## Summary
- support adding displays as panel features with size options for OLED, TFT and character LCDs
- include displays section in docs
- tweak README todos

## Testing
- `yarn build` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685fa1511cf48321ba1d5383a4d6caae